### PR TITLE
Add RPM config with Module Manager shim

### DIFF
--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/Karibou/Patches/Karibou_RPM.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/Karibou/Patches/Karibou_RPM.cfg
@@ -1,0 +1,10 @@
+@PART[*]:HAS[@INTERNAL[KaribouCabInternal]]:NEEDS[JSI]{
+	MODULE 
+	{
+		name = RasterPropMonitorComputer
+	}
+	
+	@INTERNAL {
+		@name = KaribouCabInternalRPM
+	}
+}

--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/Karibou/Spaces/cab_internal_RPM.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/Karibou/Spaces/cab_internal_RPM.cfg
@@ -1,0 +1,488 @@
+INTERNAL
+{
+	name = KaribouCabInternalRPM
+	MODEL
+	{
+		model = UmbraSpaceIndustries/Karibou/Spaces/RoverCab_IVA
+	}
+	MODULE
+	{
+		name = InternalSeat
+		seatTransformName = Kerbal01
+		allowCrewHelmet = false
+	}
+	MODULE
+	{
+		name = InternalSeat
+		seatTransformName = Kerbal02
+		allowCrewHelmet = false
+	}
+	MODULE
+	{
+		name = InternalSeat
+		seatTransformName = Kerbal03
+		allowCrewHelmet = false
+	}
+	PROP
+	{
+		name = IndicatorPanelRPM
+		position = -0.523,0.185,-0.828
+		rotation = 0.7071068,0,0,0.7071068
+		scale = 0.7,1,0.6
+	}
+	PROP
+	{
+		name = ledPanelSpeed
+		position = -0.38,0.255,-0.84
+		rotation = 0.7071068,0,0,0.7071068
+		scale = 0.8,1,0.8
+	}
+	PROP
+	{
+		name = NavBall
+		position = -0.522,0.252,-0.84
+		rotation = 0.7071068,-1.120053E-15,1.120053E-15,0.7071068
+		scale = 0.8,0.8,0.8
+	}
+	PROP
+	{
+		name = RasterPropMonitorBasicMFD
+		position = -0.2768,0.2653,-0.832
+		rotation = 0,0,0,1
+		scale = 0.5,0.5,0.5
+	}
+	PROP
+	{
+		name = RasterPropMonitorBasicMFD
+		position = -0.625,0.2653,-0.832
+		rotation = 0,0,0,1
+		scale = 0.5,0.5,0.5
+	}
+	PROP
+	{
+		name = AtmosphereDepth
+		position = -0.481,0.304,-0.84
+		rotation = 0.7071068,0,0,0.7071068
+		scale = 0.8,1,1
+	}
+	PROP
+	{
+		name = RasterPropMonitorBasicMFD
+		position = 0.6144,0.2661,-0.832
+		rotation = 0,0,0,1
+		scale = 0.5,0.5,0.5
+	}
+	PROP
+	{
+		name = RasterPropMonitorBasicMFD
+		position = 0.289,0.266,-0.832
+		rotation = 0,0,0,1
+		scale = 0.5,0.5,0.5
+	}
+	PROP
+	{
+		name = IndicatorPanelRPM
+		position = -0.0801,-0.1627,-1.4019
+		rotation = 0.8660191,0,0,0.500011
+		scale = 0.5,1,0.5
+	}
+	PROP
+	{
+		name = ledPanelSpeed
+		position = 0.06,-0.2472,-1.4557
+		rotation = 0.8660191,0,0,0.500011
+		scale = 1,1,1
+	}
+	PROP
+	{
+		name = NavBall
+		position = 0.0721,-0.1544,-1.413
+		rotation = 0.8660254,1.599948E-08,1.599948E-08,0.5
+		scale = 1,0.9999998,1
+	}
+	PROP
+	{
+		name = RasterPropMonitorBasicMFD
+		position = 0.174,-0.198,-1.423
+		rotation = 0.2588069,-3.090929E-08,-3.090929E-08,0.9659291
+		scale = 0.5,0.5,0.5
+	}
+	PROP
+	{
+		name = RasterPropMonitorBasicMFD
+		position = -0.174,-0.198,-1.423
+		rotation = 0.2588069,-3.090929E-08,-3.090929E-08,0.9659291
+		scale = 0.5,0.5,0.5
+	}
+	PROP
+	{
+		name = JSIAA_Throttle
+		position = -0.0484,-0.1583,-1.4099
+		rotation = 0.8660254,0,0,0.5
+		scale = 0.8,0.9999998,0.8800001
+	}
+	PROP
+	{
+		name = JSIActionGroupLabelButton01
+		position = 0.025,-0.1355,-1.4
+		rotation = 0.8660191,0,0,0.500011
+		scale = 0.45,1,0.45
+	}
+	PROP
+	{
+		name = JSIswitch_RCS
+		position = 0.09,-0.2134,-1.4332
+		rotation = 0.8660191,0,0,0.500011
+		scale = 0.7,1,0.7
+	}
+	PROP
+	{
+		name = JSIswitch_BRAKE
+		position = 0.07,-0.2134,-1.4332
+		rotation = 0.8660191,0,0,0.500011
+		scale = 0.7,1,0.7
+	}
+	PROP
+	{
+		name = JSIswitch_LIGHTS
+		position = 0.05,-0.2134,-1.4332
+		rotation = 0.8660191,0,0,0.500011
+		scale = 0.7,1,0.7
+	}
+	PROP
+	{
+		name = JSIswitch_GEAR
+		position = 0.03,-0.2134,-1.4332
+		rotation = 0.8660191,0,0,0.500011
+		scale = 0.7,1,0.7
+	}
+	PROP
+	{
+		name = JSIswitch_SAS
+		position = 0.01,-0.2134,-1.4332
+		rotation = 0.8660191,0,0,0.500011
+		scale = 0.7,1,0.7
+	}
+	PROP
+	{
+		name = JSIActionGroupLabelButton03
+		position = 0.025,-0.1463,-1.4062
+		rotation = 0.8660191,0,0,0.500011
+		scale = 0.45,1,0.45
+	}
+	PROP
+	{
+		name = JSIActionGroupLabelButton05
+		position = 0.025,-0.1574,-1.4126
+		rotation = 0.8660191,0,0,0.500011
+		scale = 0.45,1,0.45
+	}
+	PROP
+	{
+		name = JSIActionGroupLabelButton07
+		position = 0.025,-0.1683,-1.4189
+		rotation = 0.8660191,0,0,0.500011
+		scale = 0.45,1,0.45
+	}
+	PROP
+	{
+		name = JSIActionGroupLabelButton09
+		position = 0.025,-0.1794,-1.4253
+		rotation = 0.8660191,0,0,0.500011
+		scale = 0.45,1,0.45
+	}
+	PROP
+	{
+		name = JSIActionGroupLabelButton02
+		position = -0.016,-0.1355,-1.4
+		rotation = 0.8660191,0,0,0.500011
+		scale = 0.45,1,0.45
+	}
+	PROP
+	{
+		name = JSIActionGroupLabelButton04
+		position = -0.016,-0.1463,-1.4062
+		rotation = 0.8660191,0,0,0.500011
+		scale = 0.45,1,0.45
+	}
+	PROP
+	{
+		name = JSIActionGroupLabelButton06
+		position = -0.016,-0.1574,-1.4126
+		rotation = 0.8660191,0,0,0.500011
+		scale = 0.45,1,0.45
+	}
+	PROP
+	{
+		name = JSIActionGroupLabelButton08
+		position = -0.016,-0.1683,-1.4189
+		rotation = 0.8660191,0,0,0.500011
+		scale = 0.45,1,0.45
+	}
+	PROP
+	{
+		name = JSIActionGroupLabelButton10
+		position = -0.016,-0.1794,-1.4253
+		rotation = 0.8660191,0,0,0.500011
+		scale = 0.45,1,0.45
+	}
+	PROP
+	{
+		name = JSIStockPower
+		position = -0.046,-0.218,-1.448
+		rotation = 0.8660191,0,0,0.500011
+		scale = 1,1,0.95
+	}
+	PROP
+	{
+		name = JSIStockFuelPanel
+		position = -0.046,-0.196,-1.435
+		rotation = 0.8660191,0,0,0.500011
+		scale = 1,1,0.95
+	}
+	PROP
+	{
+		name = VSI
+		position = -0.44,0.313,-0.835
+		rotation = 0.7071068,0,0,0.7071068
+		scale = 1,0.9999998,0.9999998
+	}
+	PROP
+	{
+		name = JSIStockFuelPanel
+		position = -0.451,0.255,-0.84
+		rotation = 0.7071068,0,0,0.7071068
+		scale = 0.8,1,0.8
+	}
+	PROP
+	{
+		name = JSIStockMono
+		position = -0.451,0.235,-0.84
+		rotation = 0.7071068,0,0,0.7071068
+		scale = 0.8,1,0.8
+	}
+	PROP
+	{
+		name = JSIStockPower
+		position = -0.38,0.235,-0.84
+		rotation = 0.7071068,0,0,0.7071068
+		scale = 0.8,1,0.8
+	}
+	PROP
+	{
+		name = JSIswitch_RCS
+		position = -0.36,0.195,-0.831
+		rotation = 0.7071068,0,0,0.7071068
+		scale = 0.8,1,0.8
+	}
+	PROP
+	{
+		name = JSIAA_Throttle
+		position = -0.41,0.275,-0.84
+		rotation = 0.5,0.5,0.5,0.5
+		scale = 0.7,1,1.65
+	}
+	PROP
+	{
+		name = JSIswitch_BRAKE
+		position = -0.384,0.195,-0.831
+		rotation = 0.7071068,0,0,0.7071068
+		scale = 0.8,1,0.8
+	}
+	PROP
+	{
+		name = JSIswitch_LIGHTS
+		position = -0.408,0.195,-0.831
+		rotation = 0.7071068,0,0,0.7071068
+		scale = 0.8,1,0.8
+	}
+	PROP
+	{
+		name = JSIswitch_GEAR
+		position = -0.432,0.195,-0.831
+		rotation = 0.7071068,0,0,0.7071068
+		scale = 0.8,1,0.8
+	}
+	PROP
+	{
+		name = JSIswitch_SAS
+		position = -0.456,0.195,-0.831
+		rotation = 0.7071068,0,0,0.7071068
+		scale = 0.8,1,0.8
+	}
+	PROP
+	{
+		name = JSIswitch_StageLock
+		position = -0.48,0.195,-0.831
+		rotation = 0.7071068,0,0,0.7071068
+		scale = 0.8,1,0.8
+	}
+	PROP
+	{
+		name = JSIActionGroupLabelButton01
+		position = -0.2619,0.184,-0.84
+		rotation = 0.7071068,0,0,0.7071068
+		scale = 0.6,1,0.6
+	}
+	PROP
+	{
+		name = JSIActionGroupLabelButton02
+		position = -0.3182,0.184,-0.84
+		rotation = 0.7071068,0,0,0.7071068
+		scale = 0.6,1,0.6
+	}
+	PROP
+	{
+		name = JSIActionGroupLabelButton03
+		position = -0.2619,0.169,-0.84
+		rotation = 0.7071068,0,0,0.7071068
+		scale = 0.6,1,0.6
+	}
+	PROP
+	{
+		name = JSIActionGroupLabelButton04
+		position = -0.3182,0.169,-0.84
+		rotation = 0.7071068,0,0,0.7071068
+		scale = 0.6,1,0.6
+	}
+	PROP
+	{
+		name = JSIActionGroupLabelButton05
+		position = -0.3182,0.154,-0.84
+		rotation = 0.7071068,0,0,0.7071068
+		scale = 0.6,1,0.6
+	}
+	PROP
+	{
+		name = JSIActionGroupLabelButton06
+		position = -0.5754,0.184,-0.84
+		rotation = 0.7071068,0,0,0.7071068
+		scale = 0.6,1,0.6
+	}
+	PROP
+	{
+		name = JSIActionGroupLabelButton07
+		position = -0.632,0.184,-0.84
+		rotation = 0.7071068,0,0,0.7071068
+		scale = 0.6,1,0.6
+	}
+	PROP
+	{
+		name = JSIActionGroupLabelButton08
+		position = -0.5754,0.169,-0.84
+		rotation = 0.7071068,0,0,0.7071068
+		scale = 0.6,1,0.6
+	}
+	PROP
+	{
+		name = JSIActionGroupLabelButton09
+		position = -0.632,0.169,-0.84
+		rotation = 0.7071068,0,0,0.7071068
+		scale = 0.6,1,0.6
+	}
+	PROP
+	{
+		name = JSIActionGroupLabelButton10
+		position = -0.5754,0.154,-0.84
+		rotation = 0.7071068,0,0,0.7071068
+		scale = 0.6,1,0.69
+	}
+	PROP
+	{
+		name = RasterPropMonitorBasicMFD
+		position = 0.4518,0.2518,-0.832
+		rotation = 0,0,0,1
+		scale = 0.6,0.6,1
+	}
+	PROP
+	{
+		name = JSIActionGroupLabelButton10
+		position = 0.3254,0.154,-0.84
+		rotation = 0.7071068,0,0,0.7071068
+		scale = 0.6,1,0.69
+	}
+	PROP
+	{
+		name = JSIActionGroupLabelButton09
+		position = 0.2688,0.169,-0.84
+		rotation = 0.7071068,0,0,0.7071068
+		scale = 0.6,1,0.6
+	}
+	PROP
+	{
+		name = JSIActionGroupLabelButton08
+		position = 0.3254,0.169,-0.84
+		rotation = 0.7071068,0,0,0.7071068
+		scale = 0.6,1,0.6
+	}
+	PROP
+	{
+		name = JSIActionGroupLabelButton07
+		position = 0.2688,0.184,-0.84
+		rotation = 0.7071068,0,0,0.7071068
+		scale = 0.6,1,0.6
+	}
+	PROP
+	{
+		name = JSIActionGroupLabelButton06
+		position = 0.3254,0.184,-0.84
+		rotation = 0.7071068,0,0,0.7071068
+		scale = 0.6,1,0.6
+	}
+	PROP
+	{
+		name = JSIActionGroupLabelButton05
+		position = 0.5826,0.154,-0.84
+		rotation = 0.7071068,0,0,0.7071068
+		scale = 0.6,1,0.6
+	}
+	PROP
+	{
+		name = JSIActionGroupLabelButton04
+		position = 0.5826,0.169,-0.84
+		rotation = 0.7071068,0,0,0.7071068
+		scale = 0.6,1,0.6
+	}
+	PROP
+	{
+		name = JSIActionGroupLabelButton03
+		position = 0.6389,0.169,-0.84
+		rotation = 0.7071068,0,0,0.7071068
+		scale = 0.6,1,0.6
+	}
+	PROP
+	{
+		name = JSIActionGroupLabelButton02
+		position = 0.5826,0.184,-0.84
+		rotation = 0.7071068,0,0,0.7071068
+		scale = 0.6,1,0.6
+	}
+	PROP
+	{
+		name = JSIActionGroupLabelButton01
+		position = 0.6389,0.184,-0.84
+		rotation = 0.7071068,0,0,0.7071068
+		scale = 0.6,1,0.6
+	}
+	PROP
+	{
+		name = Compass
+		position = -0.05,-0.235,-1.473
+		rotation = 0.6123724,-0.3535534,-0.6123725,0.3535534
+		scale = 0.6,1,0.7
+	}
+	PROP
+	{
+		name = RadarAltimeter
+		position = -0.3779,0.3132,-0.8353
+		rotation = 0.7071068,0,0,0.7071068
+		scale = 1,0.9999997,0.9999997
+	}
+	PROP
+	{
+		name = AltimeterThreeHands
+		position = -0.522,0.31,-0.83
+		rotation = 0.7071068,0,0,0.7071068
+		scale = 1,0.9999997,0.9999997
+	}
+}


### PR DESCRIPTION
Adds RPM configuration to the Karibou cab, with Module Manager
configuration file so it only is used with RPM installed.