### PR TITLE
Normalizing empty tank costs for KER_Crate, KER_Tank, KER_WheelBay, and KER_WheelBay_Short

### DIFF
--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/Karibou/Parts/KER_Crate.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/Karibou/Parts/KER_Crate.cfg
@@ -50,7 +50,7 @@ PART
 		resourceNames =MetallicOre;Uraninite;Substrate;Minerals;Karbonite;ExoticMinerals,RareMetals;MaterialKits;Metals;EnrichedUranium,DepletedUranium;Polymers;Supplies;Ore;Machinery;Recyclables;SpecializedParts;Fertilizer;Hydrates;Gypsum;Dirt
 		resourceAmounts = 2500;2500;2500;2500;2500;1250,1250;2500;2500;1250,1250;2500;2500;500;2500;2500;2500;2500;2500;2500;2500
 		initialResourceAmounts = 0;0;0;0;0;0,0;0;0;0,0;0;0;0;0;0;0;0;0;0;0
-		tankCost = 7000;5000;4000;5000;4000;377000;5000;38000;1083000;22000;39000;600;50000;25000;100000;14000;1250;25;750
+		tankCost = 4400;1750;750;2000;800;375000;5000;35600;1081250;20000;6250;10;39500;17500;80000;5000;1250;25;750
 		basePartMass = 0.4
 		tankMass = 0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0
 		hasGUI = false

--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/Karibou/Parts/KER_Tank.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/Karibou/Parts/KER_Tank.cfg
@@ -37,7 +37,7 @@ PART
 	MODULE
 	{
 		name = FStextureSwitch2
-		textureNames = UmbraSpaceIndustries/Karibou/Assets/RoverKontainers;UmbraSpaceIndustries/Karibou/Assets/RoverKontainers;UmbraSpaceIndustries/Karibou/Assets/RoverKontainers;UmbraSpaceIndustries/Karibou/Assets/RoverKontainers;UmbraSpaceIndustries/Karibou/Assets/RoverKontainers;UmbraSpaceIndustries/Karibou/Assets/RoverKontainers;UmbraSpaceIndustries/Karibou/Assets/RoverKontainers;UmbraSpaceIndustries/Karibou/Assets/RoverKontainers
+		textureNames = UmbraSpaceIndustries/Karibou/Assets/RoverKontainers;UmbraSpaceIndustries/Karibou/Assets/RoverKontainers;UmbraSpaceIndustries/Karibou/Assets/RoverKontainers;UmbraSpaceIndustries/Karibou/Assets/RoverKontainers;UmbraSpaceIndustries/Karibou/Assets/RoverKontainers;UmbraSpaceIndustries/Karibou/Assets/RoverKontainers;UmbraSpaceIndustries/Karibou/Assets/RoverKontainers
 		objectNames = Frame
 		textureDisplayNames = LFO;Water;Chemicals;Mulch;LH2;LiqudFuel;MonoPropellant
 		useFuelSwitchModule = true
@@ -50,8 +50,8 @@ PART
 		name = FSfuelSwitch
 		resourceNames =LiquidFuel,Oxidizer;Water;Chemicals;Mulch;LqdHydrogen;LiquidFuel;MonoPropellant
 		resourceAmounts = 225,275;2500;2500;2500;2500;500;500
-		initialResourceAmounts = 0;0;0;0;0;0;0
-		tankCost = 1000;1000;40000;1000;1000;1000;1500
+		initialResourceAmounts = 0,0;0;0;0;0;0;0
+		tankCost = 229.5;2;40000;0;91.875;400;600
 		basePartMass = 0.4
 		tankMass = 0;0;0;0;0;0;0
 		hasGUI = false

--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/Karibou/Parts/KER_WheelBay.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/Karibou/Parts/KER_WheelBay.cfg
@@ -62,8 +62,8 @@ PART
 		name = FSfuelSwitch
 		resourceNames =LiquidFuel,Oxidizer;Water;Chemicals;Mulch;LqdHydrogen;LiquidFuel;MonoPropellant;MetallicOre;Uraninite;Substrate;Minerals;Karbonite;ExoticMinerals,RareMetals;MaterialKits;Metals;EnrichedUranium,DepletedUranium;Polymers;Supplies;Ore;Machinery;Recyclables;SpecializedParts;Fertilizer;Hydrates;Gypsum;Dirt
 		resourceAmounts = 900,1100;10000;10000;10000;10000;2000;2000;10000;10000;10000;10000;10000;5000,5000;10000;10000;5000,5000;10000;10000;2000;10000;10000;10000;10000;10000;10000;10000
-		initialResourceAmounts = 0;0;0;0;0;0;0;0;0;0;0;0;0;0,0;0;0;0,0;0;0;0;0;0;0;0;0;0
-		tankCost =4000;4000;163000;4000;4500;4000;6000;21000;11000;7000;12000;7000;1504000;14000;153500;4328500;83500;153500;1000;162500;80000;325000;53000;5000;100;3000
+		initialResourceAmounts = 0,0;0;0;0;0;0;0;0;0;0;0;0;0,0;0;0;0,0;0;0;0;0;0;0;0;0;0;0
+		tankCost = 918;8;160000;0;367.5;1600;2400;17600;7000;3000;8000;3200;1500000;20000;142400;4325000;80000;25000;40;158000;70000;320000;20000;5000;100;3000
 		basePartMass = 2
 		tankMass = 0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0
 		hasGUI = false

--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/Karibou/Parts/KER_WheelBay_Short.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/Karibou/Parts/KER_WheelBay_Short.cfg
@@ -60,10 +60,10 @@ PART
 		name = FSfuelSwitch
 		resourceNames =LiquidFuel,Oxidizer;Water;Chemicals;Mulch;LqdHydrogen;LiquidFuel;MonoPropellant;MetallicOre;Uraninite;Substrate;Minerals;Karbonite;ExoticMinerals,RareMetals;MaterialKits;Metals;EnrichedUranium,DepletedUranium;Polymers;Supplies;Ore;Machinery;Recyclables;SpecializedParts;Fertilizer;Hydrates;Gypsum;Dirt
 		resourceAmounts = 450,550;5000;5000;5000;5000;1000;1000;5000;5000;5000;5000;5000;2500,2500;5000;5000;2500,2500;5000;5000;1000;5000;5000;5000;5000;5000;5000;5000
-		initialResourceAmounts = 0;0;0;0;0;0;0;0;0;0;0;0;0;0,0;0;0;0,0;0;0;0;0;0;0;0;0;0
-		tankCost = 2000;2000;80000;2000;2000;2000;3000;14000;10000;8000;10000;8000;754000;10000;76000;2166000;44000;78000;1200;100000;50000;200000;28000;2500;50;1500
+		initialResourceAmounts = 0,0;0;0;0;0;0;0;0;0;0;0;0;0,0;0;0;0,0;0;0;0;0;0;0;0;0;0;0
+		tankCost = 459;4;80000;0;183.75;4000;1200;8800;3500;1500;4000;1600;750000;10000;71200;2162500;40000;12500;20;79000;35000;160000;10000;2500;50;1500
 		basePartMass = 1
-		tankMass = 0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0
+		tankMass = 0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0
 		hasGUI = false
 	}
 	


### PR DESCRIPTION
All of these should now be set to their base costs when empty.
See https://docs.google.com/spreadsheets/d/1rCP5mZxXl1xe5BgiHgtEqh9Dv69IKrQc9FwsG1w0h0Q/ for calculations.
Fixed an issue where the KER_Tank had an extra config showing up as RoverKontainers (extra textureName) and some issues where there were not enough initialResourceAmounts entries (tanks were starting full instead of empty).